### PR TITLE
Added empty object to createApp() as a parameter

### DIFF
--- a/01-portfolio-stages/after 2-01.The vue instance/script.js
+++ b/01-portfolio-stages/after 2-01.The vue instance/script.js
@@ -1,2 +1,2 @@
-Vue.createApp().mount("header");
-Vue.createApp().mount("#blog");
+Vue.createApp({}).mount("header");
+Vue.createApp({}).mount("#blog");


### PR DESCRIPTION
Without it `Vue.createApp({}).mount("#blog");` will throw an error `Uncaught TypeError: Cannot read properties of undefined (reading 'render') at t.mount[...]`